### PR TITLE
meta: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+---
+
+## Environment
+
+- OS:
+- Version:
+- Deployment method (Docker/Kubernetes/local):
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Logs / Screenshots
+
+```
+Paste logs here
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/jstuart0/project-athena-oss/discussions
+    about: Please ask open-ended questions in Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+---
+
+## Problem
+
+What problem are you trying to solve?
+
+## Proposed Solution
+
+What would you like to see happen?
+
+## Alternatives Considered
+
+What other approaches have you considered?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+
+What does this PR do?
+
+## Checklist
+
+- [ ] Linked issue (if applicable)
+- [ ] Tests added / updated if applicable
+- [ ] Docs updated if applicable
+- [ ] No secrets or hardcoded IPs


### PR DESCRIPTION
## Summary\n\nAdded lightweight GitHub templates to standardize issues and PRs.\n\n## Changes\n- \ — environment, steps to reproduce, expected vs actual, logs/screenshots\n- \ — problem, proposed solution, alternatives considered\n- \ — disables blank issues, links to Discussions\n- \ — linked issue, tests, docs, no secrets checklist\n\nAll templates stay under 30 lines as requested.\n\n## Completes\n- Closes #13\n\n## How to verify\n1. Open a test issue/PR in a fork to verify templates render correctly\n2. Confirm blank issues are disabled and the Discussions link appears