### PR TITLE
feat(admin-frontend): accessible Toast wiring for service-control (ATHENA-48)

### DIFF
--- a/admin/frontend/service-control.js
+++ b/admin/frontend/service-control.js
@@ -95,6 +95,9 @@ async function loadServices() {
 // Module-level flag: populated on first loadRagServicesFromRegistry() call.
 let controlAgentEnabled = false;
 
+// Status-change tracking for ATHENA-48 toast announcements.
+const _lastStatusByService = new Map();
+
 async function loadRagServicesFromRegistry() {
     try {
         const response = await apiRequest('/api/service-registry/services');
@@ -482,6 +485,32 @@ function renderRagServicesTable() {
             </div>
         `;
         return;
+    }
+
+    // Status-change announcements (ATHENA-48): one toast per flip, batched if >3 flips in a tick.
+    const flips = [];
+    for (const s of ragServices) {
+        const name = s.name;
+        if (!name) continue;
+        const current = String(s.status ?? (s.is_running ? 'healthy' : 'unhealthy'));
+        const prev = _lastStatusByService.get(name);
+        if (prev !== undefined && prev !== current) {
+            flips.push({ name, from: prev, to: current });
+        }
+        _lastStatusByService.set(name, current);
+    }
+    if (flips.length > 0 && window.Athena?.components?.Toast) {
+        const Toast = window.Athena.components.Toast;
+        const typeFor = (to) => (to === 'healthy' || to === 'running' || to === 'online')
+            ? 'success'
+            : (to === 'error' || to === 'unreachable' || to === 'down') ? 'error' : 'warning';
+        if (flips.length <= 3) {
+            for (const f of flips) {
+                Toast[typeFor(f.to)](`${f.name}: ${f.from} → ${f.to}`, { duration: 6000 });
+            }
+        } else {
+            Toast.warning(`${flips.length} services changed status`, { duration: 8000 });
+        }
     }
 
     container.innerHTML = `

--- a/admin/frontend/tool-calling.js
+++ b/admin/frontend/tool-calling.js
@@ -1182,23 +1182,10 @@ function showError(containerId, message) {
 }
 
 function showToast(message, type = 'info') {
-    // Simple toast notification (can be enhanced)
-    const colors = {
-        success: 'bg-green-600',
-        error: 'bg-red-600',
-        info: 'bg-blue-600'
-    };
-
-    const toast = document.createElement('div');
-    toast.className = `fixed bottom-4 right-4 ${colors[type]} text-white px-6 py-3 rounded-lg shadow-lg z-50 transition-opacity`;
-    toast.textContent = message;
-
-    document.body.appendChild(toast);
-
-    setTimeout(() => {
-        toast.style.opacity = '0';
-        setTimeout(() => toast.remove(), 300);
-    }, 3000);
+    const T = window.Athena?.components?.Toast;
+    if (T) return (T[type] || T.info)(message);
+    // toast.js loads before this script per index.html — this path means a misconfig
+    console.warn('[showToast] Toast component not available; dropped:', type, message);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Replaces the legacy non-accessible `showToast()` body in `admin/frontend/tool-calling.js` with a dispatcher into `Athena.components.Toast` (defined in `toast.js`, already loaded earlier in `index.html`). All ~65 existing call sites in `tool-calling.js` and `service-control.js` inherit the accessible `role="alert"` announcement automatically — no per-call-site churn.
- Adds status-change detection in `renderRagServicesTable()` so transitions (e.g. `healthy → degraded`) emit a toast. Batched to a single summary toast when >3 services flip in the same render.
- Cell-level `aria-live="polite"` retained as defense-in-depth (per ruby r1).

Proper fix for ATHENA-48; closes the regression that PR #20 left open after the original `aria-live` revert.

## Design rationale

Three options were considered (shim vs migrate-all-call-sites vs file-local alias). Ruby reviewed and recommended the shim — one change atomically fixes 65+ call sites without churn or typo surface. Migrating each call site has zero user-visible benefit over the shim.

## Test plan

- [x] `node --check admin/frontend/tool-calling.js admin/frontend/service-control.js` — no syntax errors
- [x] Vocabulary audit — every `showToast(..., 'type')` argument is one of `success | error | info | warning` (ternary `'success' : 'warning'` also covered)
- [x] Shim body confirmed: no DOM creation, pure dispatcher
- [ ] Live screen-reader (NVDA / VoiceOver) verification of toast `role="alert"` announcements — left for the human to confirm in browser

## Out of scope

- Migrating individual `showToast(...)` call sites to direct `Athena.components.Toast.*` calls (option B; pure churn given the shim)
- Removing the cell-level `aria-live` (kept as defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)